### PR TITLE
Add initial Terraform configuration for AWS resources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,30 @@
+# Terraform files
+*.tfstate
+*.tfstate.*
+*.terraform/
+.terraform/
+crash.log
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# AWS credentials
+.aws/
+*.pem
+
+# IDE/editor files
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Logs
+*.log
+
+# Misc
+.env

--- a/README.md
+++ b/README.md
@@ -1,1 +1,36 @@
 # example-aws-terraform
+
+Este repositório contém exemplos de uso do Terraform para provisionar recursos na AWS.
+
+## Conteúdo
+
+- Exemplos de configuração de infraestrutura como código
+- Scripts para criar e gerenciar recursos AWS
+
+## Pré-requisitos
+
+- [Terraform](https://www.terraform.io/)
+- Conta AWS e credenciais configuradas
+
+## Como usar
+
+1. Clone o repositório:
+    ```sh
+    git clone https://github.com/seu-usuario/example-aws-terraform.git
+    ```
+2. Acesse a pasta do projeto:
+    ```sh
+    cd example-aws-terraform
+    ```
+3. Inicialize o Terraform:
+    ```sh
+    terraform init
+    ```
+4. Aplique a configuração:
+    ```sh
+    terraform apply
+    ```
+
+## Licença
+
+Este projeto está sob a licença MIT.

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,44 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:lcDxx0Nx+ifFqTBpxz8Un27O0s+I7UNJAr/rUpSqlig=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version = "3.7.2"
+  hashes = [
+    "h1:Def/iHM4HihJCIxQ8AYoxtoVL5lVlYx0V7bX91pxwgM=",
+    "zh:14829603a32e4bc4d05062f059e545a91e27ff033756b48afbae6b3c835f508f",
+    "zh:1527fb07d9fea400d70e9e6eb4a2b918d5060d604749b6f1c361518e7da546dc",
+    "zh:1e86bcd7ebec85ba336b423ba1db046aeaa3c0e5f921039b3f1a6fc2f978feab",
+    "zh:24536dec8bde66753f4b4030b8f3ef43c196d69cccbea1c382d01b222478c7a3",
+    "zh:29f1786486759fad9b0ce4fdfbbfece9343ad47cd50119045075e05afe49d212",
+    "zh:4d701e978c2dd8604ba1ce962b047607701e65c078cb22e97171513e9e57491f",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7b8434212eef0f8c83f5a90c6d76feaf850f6502b61b53c329e85b3b281cba34",
+    "zh:ac8a23c212258b7976e1621275e3af7099e7e4a3d4478cf8d5d2a27f3bc3e967",
+    "zh:b516ca74431f3df4c6cf90ddcdb4042c626e026317a33c53f0b445a3d93b720d",
+    "zh:dc76e4326aec2490c1600d6871a95e78f9050f9ce427c71707ea412a2f2f1a62",
+    "zh:eac7b63e86c749c7d48f527671c7aee5b4e26c10be6ad7232d6860167f99dbb0",
+  ]
+}

--- a/terraform/bucket.tf
+++ b/terraform/bucket.tf
@@ -1,0 +1,63 @@
+# ==========================================
+# S3 BUCKET PARA TERRAFORM STATE
+# ==========================================
+resource "aws_s3_bucket" "terraform_state" {
+  bucket = "${var.project_name}-terraform-state-${random_id.bucket_suffix.hex}"
+
+  tags = local.common_tags
+}
+
+resource "random_id" "bucket_suffix" {
+  byte_length = 4
+}
+
+resource "aws_s3_bucket_versioning" "terraform_state" {
+  bucket = aws_s3_bucket.terraform_state.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "terraform_state" {
+  bucket = aws_s3_bucket.terraform_state.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "terraform_state" {
+  bucket = aws_s3_bucket.terraform_state.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_policy" "terraform_state" {
+  bucket = aws_s3_bucket.terraform_state.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "DenyInsecureConnections"
+        Effect    = "Deny"
+        Principal = "*"
+        Action    = "s3:*"
+        Resource = [
+          aws_s3_bucket.terraform_state.arn,
+          "${aws_s3_bucket.terraform_state.arn}/*"
+        ]
+        Condition = {
+          Bool = {
+            "aws:SecureTransport" = "false"
+          }
+        }
+      }
+    ]
+  })
+}

--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -1,0 +1,28 @@
+# ==========================================
+# DATA SOURCES
+# ==========================================
+data "aws_caller_identity" "current" {}
+
+data "aws_region" "current" {}
+
+# ==========================================
+# LOCALS
+# ==========================================
+locals {
+  account_id = data.aws_caller_identity.current.account_id
+  region     = data.aws_region.current.name
+
+  # Tags comuns para todos os recursos
+  common_tags = {
+    Environment = var.environment
+    Project     = var.project_name
+    ManagedBy   = "terraform"
+    Repository  = "terraform-bootstrap"
+    AccountId   = local.account_id
+    Region      = local.region
+    CreatedBy   = "terraform-bootstrap"
+  }
+
+  # Nome padrão para recursos
+  resource_prefix = "${var.project_name}-${var.environment}"
+}

--- a/terraform/dynamodb.tf
+++ b/terraform/dynamodb.tf
@@ -1,0 +1,23 @@
+# ==========================================
+# DYNAMODB PARA TERRAFORM LOCK
+# ==========================================
+resource "aws_dynamodb_table" "terraform_lock" {
+  name         = "${var.project_name}-terraform-lock"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "LockID"
+
+  attribute {
+    name = "LockID"
+    type = "S"
+  }
+
+  point_in_time_recovery {
+    enabled = true
+  }
+
+  server_side_encryption {
+    enabled = true
+  }
+
+  tags = local.common_tags
+}

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -1,0 +1,178 @@
+# ==========================================
+# IAM USER ADMINISTRATIVO
+# ==========================================
+resource "aws_iam_user" "admin_user" {
+  name = var.admin_user_name
+  path = "/"
+
+  tags = {
+    Name        = var.admin_user_name
+    Environment = var.environment
+    Purpose     = "Terraform Administration"
+  }
+}
+
+resource "aws_iam_user_policy_attachment" "admin_user_policy" {
+  user       = aws_iam_user.admin_user.name
+  policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
+}
+
+resource "aws_iam_access_key" "admin_user" {
+  user = aws_iam_user.admin_user.name
+}
+
+# ==========================================
+# ROLE PARA GITHUB ACTIONS (OIDC)
+# ==========================================
+# Provider OIDC para GitHub
+resource "aws_iam_openid_connect_provider" "github" {
+  url = "https://token.actions.githubusercontent.com"
+
+  client_id_list = [
+    "sts.amazonaws.com",
+  ]
+
+  thumbprint_list = [
+    "6938fd4d98bab03faadb97b34396831e3780aea1",
+    "1c58a3a8518e8759bf075b76b750d4f2df264fcd"
+  ]
+
+  tags = {
+    Name        = "GitHub-OIDC-Provider"
+    Environment = var.environment
+    Purpose     = "GitHub Actions Authentication"
+  }
+}
+
+# Role que o GitHub Actions pode assumir
+resource "aws_iam_role" "github_actions" {
+  name = "${var.project_name}-github-actions-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Effect = "Allow"
+        Principal = {
+          Federated = aws_iam_openid_connect_provider.github.arn
+        }
+        Condition = {
+          StringEquals = {
+            "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
+          }
+          StringLike = {
+            "token.actions.githubusercontent.com:sub" = [
+              "repo:${var.github_org}/${var.github_repo}:*",
+              "repo:${var.github_org}/*:*" # Permite qualquer repo da org/user
+            ]
+          }
+        }
+      }
+    ]
+  })
+
+  tags = {
+    Name        = "${var.project_name}-github-actions-role"
+    Environment = var.environment
+    Purpose     = "GitHub Actions Deployment"
+  }
+}
+
+# Policy para a role do GitHub Actions - COMPLETA
+resource "aws_iam_role_policy" "github_actions" {
+  name = "${var.project_name}-github-actions-policy"
+  role = aws_iam_role.github_actions.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "TerraformStateManagement"
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject",
+          "s3:PutObject",
+          "s3:DeleteObject",
+          "s3:ListBucket",
+          "s3:GetBucketVersioning"
+        ]
+        Resource = [
+          aws_s3_bucket.terraform_state.arn,
+          "${aws_s3_bucket.terraform_state.arn}/*"
+        ]
+      },
+      {
+        Sid    = "DynamoDBLockManagement"
+        Effect = "Allow"
+        Action = [
+          "dynamodb:GetItem",
+          "dynamodb:PutItem",
+          "dynamodb:DeleteItem",
+          "dynamodb:DescribeTable"
+        ]
+        Resource = aws_dynamodb_table.terraform_lock.arn
+      },
+      {
+        Sid    = "EC2Management"
+        Effect = "Allow"
+        Action = [
+          "ec2:*"
+        ]
+        Resource = "*"
+      },
+      {
+        Sid    = "IAMManagement"
+        Effect = "Allow"
+        Action = [
+          "iam:*"
+        ]
+        Resource = "*"
+      },
+      {
+        Sid    = "LambdaManagement"
+        Effect = "Allow"
+        Action = [
+          "lambda:*"
+        ]
+        Resource = "*"
+      },
+      {
+        Sid    = "CloudFormationManagement"
+        Effect = "Allow"
+        Action = [
+          "cloudformation:*"
+        ]
+        Resource = "*"
+      },
+      {
+        Sid    = "LogsManagement"
+        Effect = "Allow"
+        Action = [
+          "logs:*"
+        ]
+        Resource = "*"
+      },
+      {
+        Sid    = "STSManagement"
+        Effect = "Allow"
+        Action = [
+          "sts:AssumeRole",
+          "sts:GetCallerIdentity"
+        ]
+        Resource = "*"
+      },
+      {
+        Sid    = "S3GeneralAccess"
+        Effect = "Allow"
+        Action = [
+          "s3:CreateBucket",
+          "s3:DeleteBucket",
+          "s3:GetBucketLocation",
+          "s3:ListAllMyBuckets"
+        ]
+        Resource = "*"
+      }
+    ]
+  })
+}

--- a/terraform/output.tf
+++ b/terraform/output.tf
@@ -1,0 +1,42 @@
+output "s3_bucket_name" {
+  description = "Name of the S3 bucket for Terraform state"
+  value       = aws_s3_bucket.terraform_state.bucket
+}
+
+output "dynamodb_table_name" {
+  description = "Name of the DynamoDB table for Terraform locks"
+  value       = aws_dynamodb_table.terraform_lock.name
+}
+
+output "github_actions_role_arn" {
+  description = "ARN of the IAM role for GitHub Actions"
+  value       = aws_iam_role.github_actions.arn
+}
+
+output "admin_user_name" {
+  description = "Name of the admin IAM user"
+  value       = aws_iam_user.admin_user.name
+}
+
+output "admin_access_key_id" {
+  description = "Access Key ID for admin user"
+  value       = aws_iam_access_key.admin_user.id
+  sensitive   = true
+}
+
+output "admin_secret_access_key" {
+  description = "Secret Access Key for admin user"
+  value       = aws_iam_access_key.admin_user.secret
+  sensitive   = true
+}
+
+output "terraform_backend_config" {
+  description = "Terraform backend configuration"
+  value = {
+    bucket         = aws_s3_bucket.terraform_state.bucket
+    key            = "terraform.tfstate"
+    region         = data.aws_region.current.name
+    dynamodb_table = aws_dynamodb_table.terraform_lock.name
+    encrypt        = true
+  }
+}

--- a/terraform/tfvars/devops.tfvars
+++ b/terraform/tfvars/devops.tfvars
@@ -1,0 +1,6 @@
+aws_region      = "us-east-1"
+environment     = "devops"
+project_name    = "example-aws-terraform"
+github_org      = "lucas-bruzzone"
+github_repo     = "*"
+admin_user_name = "terraform-admin"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,62 @@
+variable "aws_region" {
+  description = "AWS region"
+  type        = string
+  default     = "us-east-1"
+
+  validation {
+    condition     = can(regex("^[a-z]{2}-[a-z]+-[0-9]{1}$", var.aws_region))
+    error_message = "AWS region must be a valid region format (e.g., us-east-1, eu-west-1)."
+  }
+}
+
+variable "environment" {
+  description = "Environment name"
+  type        = string
+  default     = "prod"
+
+  validation {
+    condition     = contains(["dev", "development", "staging", "prod", "production", "devops"], var.environment)
+    error_message = "Environment must be one of: dev, development, staging, prod, production, devops."
+  }
+}
+
+variable "project_name" {
+  description = "Project name for resource naming (must be lowercase, alphanumeric, and hyphens only)"
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-z0-9-]+$", var.project_name)) && length(var.project_name) >= 3 && length(var.project_name) <= 30
+    error_message = "Project name must be 3-30 characters, lowercase, alphanumeric and hyphens only."
+  }
+}
+
+variable "github_org" {
+  description = "GitHub organization name"
+  type        = string
+
+  validation {
+    condition     = length(var.github_org) > 0
+    error_message = "GitHub organization name cannot be empty."
+  }
+}
+
+variable "github_repo" {
+  description = "GitHub repository name that will assume the role"
+  type        = string
+
+  validation {
+    condition     = length(var.github_repo) > 0
+    error_message = "GitHub repository name cannot be empty."
+  }
+}
+
+variable "admin_user_name" {
+  description = "Name for the admin IAM user"
+  type        = string
+  default     = "terraform-admin"
+
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9+=,.@_-]+$", var.admin_user_name)) && length(var.admin_user_name) >= 1 && length(var.admin_user_name) <= 64
+    error_message = "Admin user name must be 1-64 characters and contain only alphanumeric characters and +=,.@_- symbols."
+  }
+}

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,0 +1,23 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = {
+      Environment = var.environment
+      Project     = var.project_name
+      ManagedBy   = "terraform"
+      Repository  = "terraform-bootstrap"
+    }
+  }
+}


### PR DESCRIPTION
- Create .gitignore to exclude Terraform and AWS-related files
- Update README.md with project details and usage instructions
- Add Terraform lock file for provider dependencies
- Implement S3 bucket for Terraform state management
- Define data sources for AWS account and region
- Create DynamoDB table for Terraform state locking
- Set up IAM user and policies for administrative access
- Configure outputs for resource details
- Add variable definitions for project configuration
- Establish Terraform provider requirements and default tags